### PR TITLE
Small correction of project description

### DIFF
--- a/book/projects/project4.md
+++ b/book/projects/project4.md
@@ -154,7 +154,7 @@ $$
 
 is the energy shift due to *flipping a single spin*.
 
-**a)** Consider a 2D lattice of arbitrary size. Show that there are only five possible values $\Delta E$ can take.
+**a)** Consider a 2D lattice of arbitrary size ($L>2$). Show that there are only five possible values $\Delta E$ can take.
 
 **b)** How can you use this result to avoid repeatedly calling the exponential function `exp(...)` in your code?
 


### PR DESCRIPTION
One group was confused why their 2x2 system didn't give five different $\Delta E$ values as expected from the project description (and in fact, I was also confused for a while). It turns out that for a 2x2 system, there are only three possible $\Delta E$ values, as all spins have the same neighbor to the left and right (and the same above and below). I just added a small detail in the project description that the five different $\Delta E$ values only apply for systems where $L>2$.